### PR TITLE
Add remarks with link to the source of Size Balanced Tree code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections.Methods/issues/75
-Your prepared branch: issue-75-94813e0d
-Your prepared working directory: /tmp/gh-issue-solver-1757779604948
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections.Methods/issues/75
+Your prepared branch: issue-75-94813e0d
+Your prepared working directory: /tmp/gh-issue-solver-1757779604948
+
+Proceed.

--- a/csharp/Platform.Collections.Methods/Trees/SizeBalancedTreeMethods.cs
+++ b/csharp/Platform.Collections.Methods/Trees/SizeBalancedTreeMethods.cs
@@ -11,6 +11,9 @@ namespace Platform.Collections.Methods.Trees
     /// </para>
     /// <para></para>
     /// </summary>
+    /// <remarks>
+    /// Based on: <a href="https://www.scribd.com/document/3072015/10-陈启峰-Size-Balanced-Tree">Size Balanced Tree by Chen Qifeng (陈启峰)</a>.
+    /// </remarks>
     /// <seealso cref="SizedBinaryTreeMethodsBase{TElement}"/>
     public abstract class SizeBalancedTreeMethods<TElement> : SizedBinaryTreeMethodsBase<TElement> where TElement: IUnsignedNumber<TElement>, IComparisonOperators<TElement, TElement, bool>
     {


### PR DESCRIPTION
## Summary
- Added XML documentation remarks section to SizeBalancedTreeMethods class
- Includes link to original Size Balanced Tree paper by Chen Qifeng (陈启峰)
- Follows same pattern as other tree implementations in the codebase

## Details
This commit resolves issue #75 by adding the missing remarks section that provides attribution to the original source of the Size Balanced Tree algorithm. The implementation follows the same documentation pattern used in `SizedAndThreadedAVLBalancedTreeMethods.cs`, which already includes similar remarks with source links.

The Size Balanced Tree (SBT) algorithm was created by Chinese competitive programmer Chen Qifeng (陈启峰) in 2006 and presented at Winter Camp 2007. This balanced binary search tree maintains balance by tracking subtree sizes and is widely used in competitive programming due to its simplicity and efficiency.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #75