### PR TITLE
Add XML documentation comments for public classes and methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections.Methods/issues/69
-Your prepared branch: issue-69-9254ea64
-Your prepared working directory: /tmp/gh-issue-solver-1757805069755
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections.Methods/issues/69
+Your prepared branch: issue-69-9254ea64
+Your prepared working directory: /tmp/gh-issue-solver-1757805069755
+
+Proceed.

--- a/csharp/Platform.Collections.Methods/Trees/SizeBalancedTreeMethods.cs
+++ b/csharp/Platform.Collections.Methods/Trees/SizeBalancedTreeMethods.cs
@@ -17,6 +17,12 @@ namespace Platform.Collections.Methods.Trees
         protected int attachCount = 0;
         const int maintainThreashold = 1;
 
+        /// <summary>
+        /// <para>
+        /// Executes actions before attaching a node to the tree.
+        /// </para>
+        /// <para></para>
+        /// </summary>
         protected override void BeforeAttach()
         {
             attachCount++;
@@ -65,6 +71,12 @@ namespace Platform.Collections.Methods.Trees
             }
         }
 
+        /// <summary>
+        /// <para>
+        /// Executes actions after attaching a node to the tree.
+        /// </para>
+        /// <para></para>
+        /// </summary>
         protected override void AfterAttach()
         {
             if (attachCount > maintainThreashold) 
@@ -156,6 +168,16 @@ namespace Platform.Collections.Methods.Trees
             ClearNode(nodeToDetach);
         }
 
+        /// <summary>
+        /// <para>
+        /// Maintains the balance of the left subtree to ensure size-balanced tree properties.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="root">
+        /// <para>The root.</para>
+        /// <para></para>
+        /// </param>
         private void LeftMaintain(ref TElement root)
         {
             if (root != TElement.Zero)
@@ -193,6 +215,16 @@ namespace Platform.Collections.Methods.Trees
             }
         }
 
+        /// <summary>
+        /// <para>
+        /// Maintains the balance of the right subtree to ensure size-balanced tree properties.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="root">
+        /// <para>The root.</para>
+        /// <para></para>
+        /// </param>
         private void RightMaintain(ref TElement root)
         {
             if (root != TElement.Zero)

--- a/csharp/Platform.Collections.Methods/Trees/SizedBinaryTreeMethodsBase.cs
+++ b/csharp/Platform.Collections.Methods/Trees/SizedBinaryTreeMethodsBase.cs
@@ -17,7 +17,6 @@ namespace Platform.Collections.Methods.Trees
     /// </para>
     /// <para></para>
     /// </summary>
-    /// <seealso cref="GenericCollectionMethodsBase{TElement}"/>
     public abstract class SizedBinaryTreeMethodsBase<TElement>   where TElement: IUnsignedNumber<TElement>, IComparisonOperators<TElement, TElement, bool>
     {
         /// <summary>


### PR DESCRIPTION
## 📋 Summary
Added comprehensive XML documentation comments for all public classes and methods as requested in issue #69.

## 🔧 Changes Made
- ✅ **SizeBalancedTreeMethods.cs**: Added XML documentation for previously undocumented methods:
  - `BeforeAttach()`: Documents actions before attaching a node to the tree
  - `AfterAttach()`: Documents actions after attaching a node to the tree  
  - `LeftMaintain()`: Documents left subtree balance maintenance
  - `RightMaintain()`: Documents right subtree balance maintenance

- ✅ **SizedBinaryTreeMethodsBase.cs**: Fixed broken XML documentation reference
  - Removed non-existent `GenericCollectionMethodsBase{TElement}` cref reference

## ✅ Verification
- All files now compile without CS1591 warnings (missing XML documentation)
- All XML documentation cref references are valid (no CS1574 warnings)
- Build passes successfully with no documentation-related warnings

## 📚 Files Covered
As mentioned in the issue, all the following files already had comprehensive XML documentation, and only SizeBalancedTreeMethods.cs needed additional documentation for some methods:

### Platform.Collections.Methods/Trees
- [x] RecursionlessSizeBalancedTreeMethods.cs ✅ (already documented)
- [x] SizeBalancedTreeMethods.cs ✅ **Updated**
- [x] SizedAndThreadedAVLBalancedTreeMethods.cs ✅ (already documented)
- [x] SizedBinaryTreeMethodsBase.cs ✅ **Updated**

### Platform.Collections.Methods/Lists  
- [x] CircularDoublyLinkedListMethods.cs ✅ (already documented)
- [x] DoublyLinkedListMethodsBase.cs ✅ (already documented)
- [x] OpenDoublyLinkedListMethods.cs ✅ (already documented)

**Note**: The GenericCollectionMethodsBase.cs file mentioned in the issue does not exist in the C# project.

## 🎯 Issue Resolution
Fixes #69

🤖 Generated with [Claude Code](https://claude.ai/code)